### PR TITLE
v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2023-03-24
+
 ### Added
 
 - Support for the 2021 product (version 2.0.0) ([#10](https://github.com/stactools-packages/esa-worldcover/pull/10))
@@ -31,5 +33,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Initial release.
 
-[Unreleased]: <https://github.com/stactools-packages/esa-worldcover/compare/v0.1.0..main>
+[Unreleased]: <https://github.com/stactools-packages/esa-worldcover/compare/v0.2.0..main>
+[0.2.0]: <https://github.com/stactools-packages/esa-worldcover/compare/v0.1.0..v0.2.0>
 [0.1.0]: <https://github.com/stactools-packages/esa-worldcover/releases/tag/v0.1.0>

--- a/src/stactools/esa_worldcover/__init__.py
+++ b/src/stactools/esa_worldcover/__init__.py
@@ -14,4 +14,4 @@ def register_plugin(registry: Registry) -> None:
     registry.register_subcommand(commands.create_esaworldcover_command)
 
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
**Release Summary:**

### Added

- Support for the 2021 product (version 2.0.0) ([#10](https://github.com/stactools-packages/esa-worldcover/pull/10))
- `create_examples.py` script ([#10](https://github.com/stactools-packages/esa-worldcover/pull/10))
- DOI, User Manual, and Validation links for 2020 and 2021 to the Collection ([#10](https://github.com/stactools-packages/esa-worldcover/pull/10))
- Grid extension ([#10](https://github.com/stactools-packages/esa-worldcover/pull/10))
- Option to use the Map data raster footprint for the Item geometry ([#10](https://github.com/stactools-packages/esa-worldcover/pull/10))

### Removed

- `scientific` extension from Collection ([#10](https://github.com/stactools-packages/esa-worldcover/pull/10))
- Verbiage specific to the 2020 product year and v1.0.0 version ([#10](https://github.com/stactools-packages/esa-worldcover/pull/10))

### Changed

- Command name now matches the package name (`esa-worldcover`) ([#10](https://github.com/stactools-packages/esa-worldcover/pull/10))

### Fixed

- Single asset Items now place all `projection` extension fields in Item properties rather than on the asset ([#10](https://github.com/stactools-packages/esa-worldcover/pull/10))

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Examples have been updated to reflect changes, if applicable
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
